### PR TITLE
feat: Allow passing a root option that is different than Vite's root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,14 @@ function getShortName(file: string, root: string) {
 /** Plugin configuration */
 interface Config extends WatchOptions {
   log?: boolean
+
+  /**
+    * File paths will be resolved against this directory.
+    *
+    * @default ViteDevServer.root
+    * @internal
+    */
+  root?: string
 }
 
 /**
@@ -25,7 +33,9 @@ export default (
 ): Plugin => ({
   name: 'vite-plugin-live-reload',
 
-  configureServer({ ws, config: { root, logger } }: ViteDevServer) {
+  configureServer({ ws, config: { root: viteRoot, logger } }: ViteDevServer) {
+    const root = config.root || viteRoot
+
     const reload = (path: string) => {
       ws.send({ type: 'full-reload', path })
       if (config.log ?? true) {


### PR DESCRIPTION
### Description 📖 

This pull request closes #2 by adding a `root` config option to resolve files against, instead of using Vite's `root`.


### Usage 🚀 

```js
import LiveReload from 'vite-plugin-live-reload'

export default defineConfig({
  plugins: [
    LiveReload(['config/routes.rb', 'app/views/**/*'], { root: process.cwd() }),
``` 

### Background 📜 

Implemented something similar to this library because I needed it, but before publishing I found this package, and thought it would be nicer to contribute to it instead.