### PR TITLE
feat: Allow reloading the page regardless of the modified file path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,12 @@ function getShortName(file: string, root: string) {
 
 /** Plugin configuration */
 interface Config extends WatchOptions {
+  /**
+   * Whether full reload should happen regardless of the file path.
+   * @default false
+   */
+  always?: boolean
+
   log?: boolean
 }
 
@@ -27,7 +33,7 @@ export default (
 
   configureServer({ ws, config: { root, logger } }: ViteDevServer) {
     const reload = (path: string) => {
-      ws.send({ type: 'full-reload', path })
+      ws.send({ type: 'full-reload', path: config.always ? '*' : path })
       if (config.log ?? true) {
         logger.info(
           chalk.green(`page reload `) + chalk.dim(getShortName(path, root)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,10 @@ function getShortName(file: string, root: string) {
 /** Plugin configuration */
 interface Config extends WatchOptions {
   /**
-   * Whether full reload should happen regardless of the file path.
+   * Whether the page should be reloaded regardless of which file is modified.
    * @default false
    */
-  always?: boolean
+  alwaysReload?: boolean
 
   log?: boolean
 }
@@ -33,7 +33,7 @@ export default (
 
   configureServer({ ws, config: { root, logger } }: ViteDevServer) {
     const reload = (path: string) => {
-      ws.send({ type: 'full-reload', path: config.always ? '*' : path })
+      ws.send({ type: 'full-reload', path: config.alwaysReload ? '*' : path })
       if (config.log ?? true) {
         logger.info(
           chalk.green(`page reload `) + chalk.dim(getShortName(path, root)),


### PR DESCRIPTION
### Description 📖 

This pull request closes #4 by adding an `always` configuration option that forces reload to happen regardless of the modified file paths.

### Usage 🚀 

```js
import LiveReload from 'vite-plugin-live-reload'

export default defineConfig({
  plugins: [
    LiveReload(['config/routes.rb', 'app/views/**/*'], { always: true, log: true }),
``` 