### PR TITLE
Update Vite peer dependency for v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "vite": "^4.0.0 || ^5.0.0"
+    "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "chokidar": "^3.5.0",


### PR DESCRIPTION
Vite has released version 6, which works with this plugin. This PR updates the `peerDependencies` to allow this plugin to work with Vite v6.