### PR TITLE
Add Vite 7 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "vite": "^4.0.0 || ^5.0.0 || ^6.0.0"
+    "vite": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "chokidar": "^3.6.0",


### PR DESCRIPTION
Vite has released version 7, which works with this plugin. 

This PR updates the peerDependencies to allow this plugin to work with Vite 7.